### PR TITLE
FloatingLabel children render function added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [[0.8.0](https://github.com/NilFoundation/react-components/compare/v0.7.1...v0.8.0)] - 2022-11-15
+### Breaking changes
+- FloatingLabel children are render function with props getter
+
+### Refactor
+- Update typescript config
+- Add useCallback to useKeyPress hook
+
 ## [[0.7.1](https://github.com/NilFoundation/react-components/compare/v0.7.0...v0.7.1)] - 2022-11-07
 ### Fixes
 - Don't render Toast content element with undefined children

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nilfoundation/react-components",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nilfoundation/react-components",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "bootstrap-sass": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nilfoundation/react-components",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "React components library based on Bootstrap 3",
   "keywords": [
     "react",

--- a/src/components/FloatingLabel/__tests__/FloatingLabel.test.tsx
+++ b/src/components/FloatingLabel/__tests__/FloatingLabel.test.tsx
@@ -17,10 +17,9 @@ describe('floatingLabel', () => {
      */
     it('renders', () => {
         const { getByRole } = render(
-            <FloatingLabel
-                text="Label"
-                render={({ onChange }) => <Input onChange={onChange} />}
-            />,
+            <FloatingLabel text="Label">
+                {propsGetter => <Input {...propsGetter()} />}
+            </FloatingLabel>,
         );
 
         expect(getByRole('textbox')).toBeInTheDocument();

--- a/src/components/FloatingLabel/stories/FloatingLabel.stories.tsx
+++ b/src/components/FloatingLabel/stories/FloatingLabel.stories.tsx
@@ -33,12 +33,17 @@ export const FloatingLabel: Story = args => (
     <FloatingLabelComponent
         text={args.text}
         htmlFor="some-input"
-        render={({ onChange }) => (
+    >
+        {propsGetter => (
             <Input
-                size={Size.lg}
-                onChange={onChange}
-                id="some-input"
+                {...propsGetter({
+                    size: Size.lg,
+                    id: 'some-input',
+                    onChange: () => {
+                        // Some action
+                    },
+                })}
             />
         )}
-    />
+    </FloatingLabelComponent>
 );

--- a/src/hooks/useKeyPress.tsx
+++ b/src/hooks/useKeyPress.tsx
@@ -3,7 +3,7 @@
  * @copyright Yury Korotovskikh 2022 <u.korotovskiy@nil.foundation>
  */
 
-import { KeyboardEvent as ElementKeyboardEvent } from 'react';
+import { KeyboardEvent as ElementKeyboardEvent, useCallback } from 'react';
 import { KeyboardEventKey } from '../enums';
 
 /**
@@ -30,24 +30,27 @@ export const useKeyPress = <T extends KeyboardEvent | ElementKeyboardEvent>(
     allowedKeys: KeyboardEventKey[],
     { preventDefault }: UseKeyPressSettings = { preventDefault: true },
 ): [onKeyPress: (e: T) => void] => {
-    const onKeyPress = (e: T) => {
-        if (allowedKeys.length === 0) {
-            return;
-        }
+    const onKeyPress = useCallback(
+        (e: T) => {
+            if (allowedKeys.length === 0) {
+                return;
+            }
 
-        const { key } = e;
+            const { key } = e;
 
-        if (!allowedKeys.some(k => k === key)) {
-            return;
-        }
+            if (!allowedKeys.some(k => k === key)) {
+                return;
+            }
 
-        if (preventDefault) {
-            e.preventDefault();
-            e.stopPropagation();
-        }
+            if (preventDefault) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
 
-        callback();
-    };
+            callback();
+        },
+        [allowedKeys, preventDefault, callback],
+    );
 
     return [onKeyPress];
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "ESNext",
     "lib": [
       "dom",
-      "es2015",
-      "es2016",
-      "es2017"
+      "es2019",
     ],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -20,15 +18,10 @@
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "declaration": true,
-    "declarationDir": "types",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "emitDeclarationOnly": true,
     "allowJs": false,
   },
   "include": ["src"],
-  "exclude": [
-    "node_modules",
-    "build",
-  ]
 }


### PR DESCRIPTION
Render function with propGetter is a better way to pass props to render function, than just pass props. It allows library users to safely add new props without worrying about rewriting any of internal component logic (In this case onChange handler). I would like to make it a default approach for components with render function.