### PR TITLE
Fix form hint text color and html tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [[0.8.1](https://github.com/NilFoundation/react-components/compare/v0.8.0...v0.8.1)] - 2022-11-19
+### Fixes
+- Fix form hint html tag and override text color
+
+## [[0.8.0](https://github.com/NilFoundation/react-components/compare/v0.7.1...v0.8.0)] - 2022-11-15
+### Breaking changes
+- FloatingLabel children are render function with props getter
+
+### Refactor
+- Update typescript config
+- Add useCallback to useKeyPress hook
+
 ## [[0.7.1](https://github.com/NilFoundation/react-components/compare/v0.7.0...v0.7.1)] - 2022-11-07
 ### Fixes
 - Don't render Toast content element with undefined children

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nilfoundation/react-components",
-  "version": "0.7.1",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nilfoundation/react-components",
-      "version": "0.7.1",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "bootstrap-sass": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nilfoundation/react-components",
-  "version": "0.7.1",
+  "version": "0.8.1",
   "description": "React components library based on Bootstrap 3",
   "keywords": [
     "react",

--- a/src/components/Form/FormHint.tsx
+++ b/src/components/Form/FormHint.tsx
@@ -29,5 +29,5 @@ export interface FormHintProps {
 export const FormHint = ({ className, children }: FormHintProps): ReactElement => {
     const formHintClassName = clsx('help-block', className && className);
 
-    return <p className={formHintClassName}>{children}</p>;
+    return <div className={formHintClassName}>{children}</div>;
 };

--- a/src/styles/_bootstrap.core.scss
+++ b/src/styles/_bootstrap.core.scss
@@ -41,3 +41,8 @@
 .has-error {
   @include form-control-validation($c-danger, $c-danger, $state-danger-bg);
 }
+
+// form hint overrides
+.help-block {
+  color: $text-muted;
+}


### PR DESCRIPTION
Replace <p> with <div> tag to ease styling and override .help-block class text color due to UX reasons.