### PR TITLE
Tscompiler target downgraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [[0.8.2](https://github.com/NilFoundation/react-components/compare/v0.8.1...v0.8.2)] - 2022-11-19
+### Fixes
+- Downgrade tscompiler target to es2016
+
 ## [[0.8.1](https://github.com/NilFoundation/react-components/compare/v0.8.0...v0.8.1)] - 2022-11-19
 ### Fixes
 - Fix form hint html tag and override text color

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nilfoundation/react-components",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nilfoundation/react-components",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "bootstrap-sass": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nilfoundation/react-components",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "React components library based on Bootstrap 3",
   "keywords": [
     "react",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "es2016",
     "lib": [
       "dom",
-      "es2019",
+      "es2016",
     ],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Downgrade tscompiler target to es2016 to allow library usage in old projects without changing babel config.