### PR TITLE
Emit types declarations into single .d.ts file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "react-dom": "^17.0.2",
         "rollup": "^2.77.2",
         "rollup-plugin-copy": "^3.4.0",
+        "rollup-plugin-dts": "^5.0.0",
         "rollup-plugin-filesize": "^9.1.2",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
@@ -28794,6 +28795,40 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/rollup-plugin-dts": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-5.0.0.tgz",
+      "integrity": "sha512-OO8ayCvuJCKaQSShyVTARxGurVVk4ulzbuvz+0zFd1f93vlnWFU5pBMT7HFeS6uj7MvvZLx4kUAarGATSU1+Ng==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.26.7"
+      },
+      "engines": {
+        "node": ">=v14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.18.6"
+      },
+      "peerDependencies": {
+        "rollup": "^3.0.0",
+        "typescript": "^4.1"
+      }
+    },
+    "node_modules/rollup-plugin-dts/node_modules/magic-string": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/rollup-plugin-filesize": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-filesize/-/rollup-plugin-filesize-9.1.2.tgz",
@@ -55062,6 +55097,27 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
+        }
+      }
+    },
+    "rollup-plugin-dts": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-5.0.0.tgz",
+      "integrity": "sha512-OO8ayCvuJCKaQSShyVTARxGurVVk4ulzbuvz+0zFd1f93vlnWFU5pBMT7HFeS6uj7MvvZLx4kUAarGATSU1+Ng==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "magic-string": "^0.26.7"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+          "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "files": [
     "build"
   ],
+  "types": "build/index.d.ts",
   "scripts": {
     "lint:ts": "eslint --ext=ts,tsx src --max-warnings=0",
     "lint:editorconfig": "npx editorconfig-checker",
@@ -91,6 +92,7 @@
     "react-dom": "^17.0.2",
     "rollup": "^2.77.2",
     "rollup-plugin-copy": "^3.4.0",
+    "rollup-plugin-dts": "^5.0.0",
     "rollup-plugin-filesize": "^9.1.2",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import postcss from "rollup-plugin-postcss";
 import filesize from 'rollup-plugin-filesize';
 import copy from 'rollup-plugin-copy';
+import dts from 'rollup-plugin-dts';
 
 const packageJson = require("./package.json");
 
@@ -35,6 +36,7 @@ export default [
             }),
             typescript({
                 tsconfig: "./tsconfig.json",
+                declaration: false,
                 exclude: ["**/__tests__", "**/*.test.tsx", "**/*.stories.**"],
                 noEmitOnError: true,
             }),
@@ -54,5 +56,11 @@ export default [
             filesize(),
         ],
         external: ['react', 'react-dom']
-    }
+    },
+    {
+        input: "src/index.ts",
+        output: [{ file: "build/index.d.ts", format: "es" }],
+        plugins: [dts()],
+        external: [/\.scss$/],
+    },
 ];


### PR DESCRIPTION
Emit type declarations into single .d.ts file to get faster type checking, smaller bundle size and dodge potential components private APIs leaks.