### PR TITLE
build: Update GitHub Actions to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Setup Nodejs
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
     - name: Install dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,8 +8,8 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Updated actions/checkout and actions/setup-node to v4 in our CI workflows to stay current with the latest versions.

[actions/checkout@v4 Release Notes](https://github.com/actions/checkout/releases/tag/v4.2.2)
[actions/setup-node@v4 Release Notes](https://github.com/actions/setup-node/releases/tag/v4.4.0)